### PR TITLE
Replacing AdvancedHints to HintServiceMeow

### DIFF
--- a/CustomHint/Commands/Commands.cs
+++ b/CustomHint/Commands/Commands.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Linq;
 using CommandSystem;
 using Exiled.API.Features;
 using RemoteAdmin;
@@ -18,7 +19,7 @@ namespace CustomHint.Commands
 
             if (!Plugin.Instance.Config.EnableHudCommands)
             {
-                response = Plugin.Instance.Translation.CommandDisabledMessage;
+                response = "This command is disabled.";
                 return false;
             }
 
@@ -30,19 +31,23 @@ namespace CustomHint.Commands
 
             if (player.DoNotTrack)
             {
-                response = Plugin.Instance.Translation.DntEnabledMessage;
+                response = "Disable DNT mode to use this command.";
                 return false;
             }
 
             if (Plugin.Instance.HiddenHudPlayers.Contains(player.UserId))
             {
-                response = Plugin.Instance.Translation.HideHudAlreadyHiddenMessage;
+                response = "HUD is already hidden.";
                 return false;
             }
 
             Plugin.Instance.HiddenHudPlayers.Add(player.UserId);
             Plugin.Instance.SaveHiddenHudPlayers();
-            response = Plugin.Instance.Translation.HideHudSuccessMessage;
+
+            Plugin.Instance.Hints.RemoveHints(player);
+            Plugin.Instance.Hints.AssignHints(player);
+
+            response = "HUD successfully hidden.";
             return true;
         }
     }
@@ -56,36 +61,40 @@ namespace CustomHint.Commands
 
         public bool Execute(ArraySegment<string> arguments, ICommandSender sender, out string response)
         {
+            var player = Player.Get(sender);
+
             if (!Plugin.Instance.Config.EnableHudCommands)
             {
-                response = Plugin.Instance.Translation.CommandDisabledMessage;
+                response = "This command is disabled.";
                 return false;
             }
 
-            if (sender is PlayerCommandSender playerSender)
+            if (player == null)
             {
-                var player = Player.Get(playerSender.ReferenceHub);
-
-                if (player == null || player.DoNotTrack)
-                {
-                    response = Plugin.Instance.Translation.DntEnabledMessage;
-                    return false;
-                }
-
-                if (!Plugin.Instance.HiddenHudPlayers.Contains(player.UserId))
-                {
-                    response = Plugin.Instance.Translation.ShowHudAlreadyShownMessage;
-                    return false;
-                }
-
-                Plugin.Instance.HiddenHudPlayers.Remove(player.UserId);
-                Plugin.Instance.SaveHiddenHudPlayers();
-                response = Plugin.Instance.Translation.ShowHudSuccessMessage;
-                return true;
+                response = "This command is for players only.";
+                return false;
             }
 
-            response = "This command is for players only.";
-            return false;
+            if (player.DoNotTrack)
+            {
+                response = "Disable DNT mode to use this command.";
+                return false;
+            }
+
+            if (!Plugin.Instance.HiddenHudPlayers.Contains(player.UserId))
+            {
+                response = "HUD is already visible.";
+                return false;
+            }
+
+            Plugin.Instance.HiddenHudPlayers.Remove(player.UserId);
+            Plugin.Instance.SaveHiddenHudPlayers();
+
+            Plugin.Instance.Hints.RemoveHints(player);
+            Plugin.Instance.Hints.AssignHints(player);
+
+            response = "HUD successfully restored.";
+            return true;
         }
     }
 }

--- a/CustomHint/Commands/Commands.cs
+++ b/CustomHint/Commands/Commands.cs
@@ -19,7 +19,7 @@ namespace CustomHint.Commands
 
             if (!Plugin.Instance.Config.EnableHudCommands)
             {
-                response = "This command is disabled.";
+                response = Plugin.Instance.Translation.CommandDisabledMessage;
                 return false;
             }
 
@@ -31,13 +31,13 @@ namespace CustomHint.Commands
 
             if (player.DoNotTrack)
             {
-                response = "Disable DNT mode to use this command.";
+                response = Plugin.Instance.Translation.DntEnabledMessage;
                 return false;
             }
 
             if (Plugin.Instance.HiddenHudPlayers.Contains(player.UserId))
             {
-                response = "HUD is already hidden.";
+                response = Plugin.Instance.Translation.HideHudAlreadyHiddenMessage;
                 return false;
             }
 
@@ -47,7 +47,7 @@ namespace CustomHint.Commands
             Plugin.Instance.Hints.RemoveHints(player);
             Plugin.Instance.Hints.AssignHints(player);
 
-            response = "HUD successfully hidden.";
+            response = Plugin.Instance.Translation.HideHudSuccessMessage;
             return true;
         }
     }
@@ -65,7 +65,7 @@ namespace CustomHint.Commands
 
             if (!Plugin.Instance.Config.EnableHudCommands)
             {
-                response = "This command is disabled.";
+                response = Plugin.Instance.Translation.CommandDisabledMessage;
                 return false;
             }
 
@@ -77,13 +77,13 @@ namespace CustomHint.Commands
 
             if (player.DoNotTrack)
             {
-                response = "Disable DNT mode to use this command.";
+                response = Plugin.Instance.Translation.DntEnabledMessage;
                 return false;
             }
 
             if (!Plugin.Instance.HiddenHudPlayers.Contains(player.UserId))
             {
-                response = "HUD is already visible.";
+                response = Plugin.Instance.Translation.ShowHudAlreadyShownMessage;
                 return false;
             }
 
@@ -93,7 +93,7 @@ namespace CustomHint.Commands
             Plugin.Instance.Hints.RemoveHints(player);
             Plugin.Instance.Hints.AssignHints(player);
 
-            response = "HUD successfully restored.";
+            response = Plugin.Instance.Translation.ShowHudSuccessMessage;
             return true;
         }
     }

--- a/CustomHint/Configs/Config.cs
+++ b/CustomHint/Configs/Config.cs
@@ -19,13 +19,7 @@ namespace CustomHint.Configs
         [Description("Enable or disable automatic plugin updates.")]
         public bool AutoUpdater { get; set; } = true;
 
-        [Description("Enable or disable game hints.")]
-        public bool GameHint { get; set; } = true;
-
-        [Description("Enable or disable hints for spectators.")]
-        public bool HintForSpectatorsIsEnabled { get; set; } = true;
-
-        [Description("The interval for changing spectator hints (in seconds).")]
+        [Description("The interval for changing {hints} placeholder (in seconds).")]
         public float HintMessageTime { get; set; } = 5f;
 
         [Description("Default role name for players without a role.")]
@@ -40,12 +34,30 @@ namespace CustomHint.Configs
         [Description("Enable counting Overwatch players in placeholder {spectators_num}.")]
         public bool EnableOverwatchCounting { get; set; } = true;
 
-        [Description("Ignored roles.")]
-        public List<RoleTypeId> ExcludedRoles { get; set; } = new List<RoleTypeId>
+        [Description("List of hints.")]
+        public List<HintConfig> Hints { get; set; } = new()
         {
-            RoleTypeId.Overwatch,
-            RoleTypeId.Filmmaker,
-            RoleTypeId.Scp079
+            new HintConfig
+            {
+                Id = "firsthint",
+                Text = "Hello World!",
+                FontSize = 15,
+                PositionX = 500,
+                PositionY = 500,
+                CanBeHidden = true,
+                Roles = new List<RoleTypeId> { RoleTypeId.ClassD }
+            }
         };
+    }
+
+    public class HintConfig
+    {
+        public string Id { get; set; }
+        public string Text { get; set; }
+        public float FontSize { get; set; }
+        public float PositionX { get; set; }
+        public float PositionY { get; set; }
+        public bool CanBeHidden { get; set; }
+        public List<RoleTypeId> Roles { get; set; } = new();
     }
 }

--- a/CustomHint/Configs/Translation.cs
+++ b/CustomHint/Configs/Translation.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.ComponentModel;
 using Exiled.API.Interfaces;
 using PlayerRoles;
@@ -7,26 +7,14 @@ namespace CustomHint.Configs
 {
     public class Translation : ITranslation
     {
-        [Description("Hint message for spectators.")]
-        public string HintMessageForSpectators { get; set; } = "<size=75%>{servername}\n{ip}:{port}\n\n{player_nickname}, spec, duration: {round_duration_hours}:{round_duration_minutes}:{round_duration_seconds}.\nRole: {player_role}\nTPS: {tps}/60\n\nInformation:\nClass-D personnel: {classd_num} || Scientists: {scientist_num} || Facility Guards: {facilityguard_num} || MTF: {mtf_num} || CI: {ci_num} || SCPs: {scp_num} || Spectators: {spectators_num}\nGenerators activated: {generators_activated}/{generators_max}\n\n{hints}</size>";
-
-        [Description("Hint message for rounds lasting up to 59 seconds.")]
-        public string HintMessageUnderMinute { get; set; } = "<size=75%>{servername}\n{ip}:{port}\n\nQuick start! {player_nickname}, round time: {round_duration_seconds}s.\nGame Role: {player_gamerole} || Server Role: {player_role}\nTPS: {tps}/60</size>\n\nReal time: {current_time}";
-
-        [Description("Hint message for rounds lasting from 1 to 59 min & 59 sec")]
-        public string HintMessageUnderHour { get; set; } = "<size=75%>{servername}\n{ip}:{port}\n\nStill going, {player_nickname}! Time: {round_duration_minutes}:{round_duration_seconds}.\nGame Role: {player_gamerole} || Server Role: {player_role}\nTPS: {tps}/60</size>\n\nReal time: {current_time}";
-
-        [Description("Hint message for rounds lasting 1 hour or more.")]
-        public string HintMessageOverHour { get; set; } = "<size=75%>{servername}\n{ip}:{port}\n\nLong run, {player_nickname}! Duration: {round_duration_hours}:{round_duration_minutes}:{round_duration_seconds}.\nGame Role: {player_gamerole} || Server Role: {player_role}\nTPS: {tps}/60</size>\n\nReal time: {current_time}";
-
         [Description("Message displayed when the HUD is successfully hidden.")]
-        public string HideHudSuccessMessage { get; set; } = "<color=green>You have successfully hidden the server HUD! To get the HUD back, use .showhud</color>";
+        public string HideHudSuccessMessage { get; set; } = "<color=green>You have successfully hidden the server HUD! Changes are applied after a role change. To get the HUD back, use .showhud.</color>";
 
         [Description("Message displayed when HUD is already hidden.")]
         public string HideHudAlreadyHiddenMessage { get; set; } = "<color=red>You've already hidden the server HUD.</color>";
 
         [Description("Message displayed when HUD is successfully shown.")]
-        public string ShowHudSuccessMessage { get; set; } = "<color=green>You have successfully returned the server HUD! To hide again, use .hidehud</color>";
+        public string ShowHudSuccessMessage { get; set; } = "<color=green>You have successfully returned the server HUD! Changes are applied after a role change. To hide again, use .hidehud</color>";
 
         [Description("Message displayed when HUD is already shown.")]
         public string ShowHudAlreadyShownMessage { get; set; } = "<color=red>You already have the server HUD displayed.</color>";
@@ -36,6 +24,14 @@ namespace CustomHint.Configs
 
         [Description("Message displayed when commands are disabled on the server.")]
         public string CommandDisabledMessage { get; set; } = "<color=red>This command is disabled on the server.</color>";
+
+        [Description("Round time.")]
+        public Dictionary<string, string> RoundTimeFormats { get; set; } = new()
+        {
+            { "seconds", "{round_duration_seconds} seconds" },
+            { "minutes", "{round_duration_minutes} minutes {round_duration_seconds} seconds" },
+            { "hours", "{round_duration_hours} hours {round_duration_minutes} minutes {round_duration_seconds} seconds" }
+        };
 
         [Description("Game Role of a player, {player_gamerole} is placeholder.")]
         public List<RoleName> GameRoles { get; set; } = new()

--- a/CustomHint/Configs/Translation.cs
+++ b/CustomHint/Configs/Translation.cs
@@ -8,13 +8,13 @@ namespace CustomHint.Configs
     public class Translation : ITranslation
     {
         [Description("Message displayed when the HUD is successfully hidden.")]
-        public string HideHudSuccessMessage { get; set; } = "<color=green>You have successfully hidden the server HUD! Changes are applied after a role change. To get the HUD back, use .showhud.</color>";
+        public string HideHudSuccessMessage { get; set; } = "<color=green>You have successfully hidden the server HUD! To get the HUD back, use .showhud.</color>";
 
         [Description("Message displayed when HUD is already hidden.")]
         public string HideHudAlreadyHiddenMessage { get; set; } = "<color=red>You've already hidden the server HUD.</color>";
 
         [Description("Message displayed when HUD is successfully shown.")]
-        public string ShowHudSuccessMessage { get; set; } = "<color=green>You have successfully returned the server HUD! Changes are applied after a role change. To hide again, use .hidehud</color>";
+        public string ShowHudSuccessMessage { get; set; } = "<color=green>You have successfully returned the server HUD! To hide again, use .hidehud</color>";
 
         [Description("Message displayed when HUD is already shown.")]
         public string ShowHudAlreadyShownMessage { get; set; } = "<color=red>You already have the server HUD displayed.</color>";

--- a/CustomHint/Handlers/Methods.cs
+++ b/CustomHint/Handlers/Methods.cs
@@ -92,17 +92,17 @@ namespace CustomHint.Handlers
 
             if (roundDuration.TotalSeconds <= 60)
                 return translationroundtime["seconds"]
-                    .Replace("{round_duration_seconds}", roundDuration.Seconds.ToString());
+                    .Replace("{round_duration_seconds}", roundDuration.Seconds.ToString("D2"));
 
             if (roundDuration.TotalMinutes < 60)
                 return translationroundtime["minutes"]
-                    .Replace("{round_duration_minutes}", roundDuration.Minutes.ToString())
-                    .Replace("{round_duration_seconds}", roundDuration.Seconds.ToString());
+                    .Replace("{round_duration_minutes}", roundDuration.Minutes.ToString("D2"))
+                    .Replace("{round_duration_seconds}", roundDuration.Seconds.ToString("D2"));
 
             return translationroundtime["hours"]
-                .Replace("{round_duration_hours}", roundDuration.Hours.ToString())
-                .Replace("{round_duration_minutes}", roundDuration.Minutes.ToString())
-                .Replace("{round_duration_seconds}", roundDuration.Seconds.ToString());
+                .Replace("{round_duration_hours}", roundDuration.Hours.ToString("D2"))
+                .Replace("{round_duration_minutes}", roundDuration.Minutes.ToString("D2"))
+                .Replace("{round_duration_seconds}", roundDuration.Seconds.ToString("D2"));
         }
 
         public struct RoleCounts

--- a/CustomHint/Handlers/Methods.cs
+++ b/CustomHint/Handlers/Methods.cs
@@ -86,6 +86,25 @@ namespace CustomHint.Handlers
             return counts;
         }
 
+        public static string GetRoundTime(TimeSpan roundDuration)
+        {
+            var translationroundtime = Plugin.Instance.Translation.RoundTimeFormats;
+
+            if (roundDuration.TotalSeconds <= 60)
+                return translationroundtime["seconds"]
+                    .Replace("{round_duration_seconds}", roundDuration.Seconds.ToString());
+
+            if (roundDuration.TotalMinutes < 60)
+                return translationroundtime["minutes"]
+                    .Replace("{round_duration_minutes}", roundDuration.Minutes.ToString())
+                    .Replace("{round_duration_seconds}", roundDuration.Seconds.ToString());
+
+            return translationroundtime["hours"]
+                .Replace("{round_duration_hours}", roundDuration.Hours.ToString())
+                .Replace("{round_duration_minutes}", roundDuration.Minutes.ToString())
+                .Replace("{round_duration_seconds}", roundDuration.Seconds.ToString());
+        }
+
         public struct RoleCounts
         {
             public int ClassD;

--- a/CustomHint/Handlers/PlayerEvents.cs
+++ b/CustomHint/Handlers/PlayerEvents.cs
@@ -1,5 +1,6 @@
-﻿using Exiled.API.Features;
+using Exiled.API.Features;
 using Exiled.Events.EventArgs.Player;
+using MEC;
 
 namespace CustomHint.Handlers
 {
@@ -17,6 +18,42 @@ namespace CustomHint.Handlers
                 Plugin.Instance.SaveHiddenHudPlayers();
                 Log.Debug($"Player {player.Nickname} ({player.UserId}) has DNT enabled and was removed from HiddenHudPlayers.");
             }
+
+            Plugin.Instance.Hints.AssignHints(ev.Player);
         }
+
+        public void OnPlayerSpawned(SpawnedEventArgs ev)
+        {
+            Plugin.Instance.Hints.AssignHints(ev.Player);
+        }
+
+        public void OnChangingRole(ChangingRoleEventArgs ev)
+        {
+            Player player = ev.Player;
+
+            if (player == null)
+            {
+                Log.Warn("OnChangingRole: Player is null, skipping hint update.");
+                return;
+            }
+
+            Log.Debug($"Player {player.Nickname} ({player.UserId}) is changing role to {ev.NewRole}. Removing old hints...");
+
+            Plugin.Instance.Hints.RemoveHints(player);
+
+            Timing.CallDelayed(0.5f, () =>
+            {
+                if (player.Role.Type == ev.NewRole)
+                {
+                    Log.Debug($"Assigning new hints to {player.Nickname} ({player.UserId}) after role change...");
+                    Plugin.Instance.Hints.AssignHints(player);
+                }
+                else
+                {
+                    Log.Warn($"Role mismatch detected for {player.Nickname}. Expected {ev.NewRole}, but got {player.Role.Type}. Skipping hint assignment.");
+                }
+            });
+        }
+
     }
 }

--- a/CustomHint/Handlers/RoundEvents.cs
+++ b/CustomHint/Handlers/RoundEvents.cs
@@ -17,7 +17,7 @@ namespace CustomHint.Handlers
 
         public void OnWaitingForPlayers()
         {
-            Log.Debug("Waiting for players, enabling DisplayHintWFP.");
+            Log.Debug("Waiting for players...");
             _isRoundActive = false;
 
             Timing.KillCoroutines(_hintCoroutine);
@@ -33,7 +33,12 @@ namespace CustomHint.Handlers
 
             Plugin.Instance.Hints.LoadHints();
             Plugin.Instance.Hints.StartHintUpdater();
-            _hintCoroutine = Timing.RunCoroutine(Plugin.Instance.Hints.ContinuousHintDisplay());
+
+            foreach (var player in Player.List)
+            {
+                Plugin.Instance.Hints.RemoveHints(player);
+                Plugin.Instance.Hints.AssignHints(player);
+            }
         }
 
         public void OnRoundEnded(RoundEndedEventArgs ev)
@@ -43,6 +48,11 @@ namespace CustomHint.Handlers
 
             Timing.KillCoroutines(_hintCoroutine);
             Plugin.Instance.Hints.StopHintUpdater();
+
+            foreach (var player in Player.List)
+            {
+                Plugin.Instance.Hints.RemoveHints(player);
+            }
         }
     }
 }

--- a/CustomHint/Plugin.cs
+++ b/CustomHint/Plugin.cs
@@ -217,7 +217,7 @@ namespace CustomHint
 
                         string targetPath;
                         if (fileName.Equals("CustomHint.dll", StringComparison.OrdinalIgnoreCase) ||
-                            fileName.Equals("AdvancedHints.dll", StringComparison.OrdinalIgnoreCase))
+                            fileName.Equals("HintServiceMeow.dll", StringComparison.OrdinalIgnoreCase))
                         {
                             targetPath = Path.Combine(Paths.Plugins, fileName);
                         }

--- a/CustomHint/Plugin.cs
+++ b/CustomHint/Plugin.cs
@@ -22,7 +22,6 @@ namespace CustomHint
         public HintsSystem Hints { get; private set; }
         public HashSet<string> HiddenHudPlayers { get; private set; } = new HashSet<string>();
 
-        private CoroutineHandle _hintCoroutine;
         private string HudConfig = FileDotNet.GetPath("HiddenHudPlayers.yml");
 
         private static readonly IDeserializer Deserializer = new DeserializerBuilder()
@@ -40,7 +39,7 @@ namespace CustomHint
 
         public override string Name => "CustomHint";
         public override string Author => "Narin & BTF Team";
-        public override Version Version => new Version(1, 4, 1);
+        public override Version Version => new Version(1, 5, 0);
         public override Version RequiredExiledVersion => new Version(9, 0, 0);
 
         public override void OnEnabled()


### PR DESCRIPTION
**⚠ WARNING!**  
Before starting the server, please remove *AdvancedHints.dll* from `.../EXILED/Plugins`, and then upload *HintServiceMeow.dll* to the same directory.


Removed the following items from the config: `hint_message_for_spectators`, `hint_message_under_minute`, `hint_message_under_hour`, `hint_message_over_hour`, `game_hint`, and `hint_for_spectators_is_enabled`. Instead, I added `hints` to `[port]-config.yml`.
Example of `[port]-config.yml`:
```yaml
custom_hint:
# Plugin enabled (bool)?
  is_enabled: true
  # Debug mode?
  debug: false
  # Enable or disable HUD-related commands.
  enable_hud_commands: true
  # Enable or disable automatic plugin updates.
  auto_updater: true
  # The interval for changing {hints} placeholder (in seconds).
  hint_message_time: 5
  # Default role name for players without a role.
  default_role_name: 'Player'
  # Default role color (for players without roles).
  default_role_color: 'white'
  # Server timezone for placeholder. Use 'UTC' by default or a valid timezone ID (e.g., 'Europe/Kyiv').
  server_time_zone: 'UTC'
  # Enable counting Overwatch players in placeholder {spectators_num}.
  enable_overwatch_counting: true
  # List of hints.
  hints:
  - id: 'firsthint'
    text: 'Hello World!'
    font_size: 15
    position_x: 500
    position_y: 500
    can_be_hidden: true
    roles:
    - ClassD
```
Additionally, I added a new placeholder `{round_time}`, which outputs text like this as an example: `{round_duration_hours} hours {round_duration_minutes} minutes {round_duration_seconds} seconds`. You can configure the placeholder in `[port]-translation.yml`, which now looks like this:  
```yaml
custom_hint:
# Message displayed when the HUD is successfully hidden.
  hide_hud_success_message: '<color=green>You have successfully hidden the server HUD! To get the HUD back, use .showhud.</color>'
  # Message displayed when HUD is already hidden.
  hide_hud_already_hidden_message: '<color=red>You''ve already hidden the server HUD.</color>'
  # Message displayed when HUD is successfully shown.
  show_hud_success_message: '<color=green>You have successfully returned the server HUD! To hide again, use .hidehud</color>'
  # Message displayed when HUD is already shown.
  show_hud_already_shown_message: '<color=red>You already have the server HUD displayed.</color>'
  # Message displayed when DNT (Do Not Track) mode is enabled.
  dnt_enabled_message: '<color=red>Disable DNT (Do Not Track) mode.</color>'
  # Message displayed when commands are disabled on the server.
  command_disabled_message: '<color=red>This command is disabled on the server.</color>'
  # Round time.
  round_time_formats:
    seconds: '{round_duration_seconds} seconds'
    minutes: '{round_duration_minutes} minutes {round_duration_seconds} seconds'
    hours: '{round_duration_hours} hours {round_duration_minutes} minutes {round_duration_seconds} seconds'
  # Game Role of a player, {player_gamerole} is placeholder.
  game_roles:
  - role: Tutorial
    name: 'Tutorial'
  - role: ClassD
    name: 'Class-D'
  - role: Scientist
    name: 'Scientist'
  - role: FacilityGuard
    name: 'Facility Guard'
  - role: Filmmaker
    name: 'Film Maker'
  - role: Overwatch
    name: 'Overwatch'
  - role: NtfPrivate
    name: 'MTF Private'
  - role: NtfSergeant
    name: 'MTF Sergeant'
  - role: NtfSpecialist
    name: 'MTF Specialist'
  - role: NtfCaptain
    name: 'MTF Captain'
  - role: ChaosConscript
    name: 'CI Conscript'
  - role: ChaosRifleman
    name: 'CI Rifleman'
  - role: ChaosRepressor
    name: 'CI Repressor'
  - role: ChaosMarauder
    name: 'CI Marauder'
  - role: Scp049
    name: 'SCP-049'
  - role: Scp0492
    name: 'SCP-049-2'
  - role: Scp079
    name: 'SCP-079'
  - role: Scp096
    name: 'SCP-096'
  - role: Scp106
    name: 'SCP-106'
  - role: Scp173
    name: 'SCP-173'
  - role: Scp939
    name: 'SCP-939'
```