### PR TITLE
Added the synchronization hints setting

### DIFF
--- a/CustomHint/Configs/Config.cs
+++ b/CustomHint/Configs/Config.cs
@@ -34,6 +34,9 @@ namespace CustomHint.Configs
         [Description("Enable counting Overwatch players in placeholder {spectators_num}.")]
         public bool EnableOverwatchCounting { get; set; } = true;
 
+        [Description("Sync speed for hints. Available values: UnSync, Slowest, Slow, Normal, Fast, Fastest.")]
+        public string SyncSpeed { get; set; } = "Fastest";
+
         [Description("List of hints.")]
         public List<HintConfig> Hints { get; set; } = new()
         {

--- a/CustomHint/Handlers/Hints.cs
+++ b/CustomHint/Handlers/Hints.cs
@@ -9,6 +9,7 @@ using CustomHint.API;
 using HintServiceMeow.Core.Models.Hints;
 using HintServiceMeow.Core.Utilities;
 using HintServiceMeow.Core.Enum;
+using PlayerRoles;
 
 namespace CustomHint.Handlers
 {
@@ -137,7 +138,7 @@ namespace CustomHint.Handlers
                         string processedText = ReplacePlaceholders(hint.Text, player, Round.ElapsedTime);
                         return processedText.Replace(hintIdPlaceholder, processedText);
                     },
-                    SyncSpeed = HintSyncSpeed.Fastest,
+                    SyncSpeed = GetSyncSpeed(),
                     FontSize = (int)hint.FontSize,
                     TargetX = hint.PositionX,
                     TargetY = hint.PositionY
@@ -180,6 +181,17 @@ namespace CustomHint.Handlers
             }
 
             playerDisplay.ClearHint();
+        }
+
+        private HintSyncSpeed GetSyncSpeed()
+        {
+            if (Enum.TryParse(Plugin.Instance.Config.SyncSpeed, true, out HintSyncSpeed syncSpeed))
+            {
+                return syncSpeed;
+            }
+
+            Log.Warn($"Invalid sync speed '{Plugin.Instance.Config.SyncSpeed}', using default: Fastest");
+            return HintSyncSpeed.Fastest;
         }
 
         private string ReplacePlaceholders(string message, Player player, TimeSpan roundDuration)

--- a/CustomHint/Handlers/Hints.cs
+++ b/CustomHint/Handlers/Hints.cs
@@ -9,7 +9,6 @@ using CustomHint.API;
 using HintServiceMeow.Core.Models.Hints;
 using HintServiceMeow.Core.Utilities;
 using HintServiceMeow.Core.Enum;
-using PlayerRoles;
 
 namespace CustomHint.Handlers
 {

--- a/CustomHint/Handlers/Methods.cs
+++ b/CustomHint/Handlers/Methods.cs
@@ -37,7 +37,7 @@ namespace CustomHint.Handlers
             }
         }
 
-        public static RoleCounts CountRoles(bool includeOverwatchInSpectators = true)
+        public static RoleCounts CountRoles()
         {
             var counts = new RoleCounts();
 

--- a/CustomHint/Handlers/RoundEvents.cs
+++ b/CustomHint/Handlers/RoundEvents.cs
@@ -1,4 +1,3 @@
-using MEC;
 using Exiled.API.Features;
 using Exiled.Events.EventArgs.Server;
 using System.Threading.Tasks;
@@ -7,7 +6,6 @@ namespace CustomHint.Handlers
 {
     public class RoundEvents
     {
-        private CoroutineHandle _hintCoroutine;
         private bool _isRoundActive;
 
         public bool IsRoundActive
@@ -20,7 +18,6 @@ namespace CustomHint.Handlers
             Log.Debug("Waiting for players...");
             _isRoundActive = false;
 
-            Timing.KillCoroutines(_hintCoroutine);
             Plugin.Instance.SaveHiddenHudPlayers();
 
             Task.Run(() => Plugin.Instance.CheckForUpdates());
@@ -28,7 +25,7 @@ namespace CustomHint.Handlers
 
         public void OnRoundStarted()
         {
-            Log.Debug("Round started, enabling hints.");
+            Log.Debug("Round started.");
             _isRoundActive = true;
 
             Plugin.Instance.Hints.LoadHints();
@@ -43,10 +40,9 @@ namespace CustomHint.Handlers
 
         public void OnRoundEnded(RoundEndedEventArgs ev)
         {
-            Log.Debug("Round ended, disabling hints.");
+            Log.Debug("Round ended.");
             _isRoundActive = false;
 
-            Timing.KillCoroutines(_hintCoroutine);
             Plugin.Instance.Hints.StopHintUpdater();
 
             foreach (var player in Player.List)


### PR DESCRIPTION
A new setting has been added: hints synchronization speed in `xxxx-config.yml`. The essence of this setting is simple – the speed of hints updates. Here's how it looks in the config:
```yaml
# Sync speed for hints. Available values: UnSync, Slowest, Slow, Normal, Fast, Fastest.
sync_speed: 'Fastest'
```
This was done for the future, as with the release of SCP:SL 14.1 (Tooth & Nail), where LabAPI will be updated and the hint rate limit will be removed. After the 14.1 update of SCP:SL and HintServerMeow, there will be no synchronization limits for hints when set to `Fastest`.